### PR TITLE
Add SP Tour Pages WordPress plugin

### DIFF
--- a/sp-tour-pages/assets/css/admin-meta.css
+++ b/sp-tour-pages/assets/css/admin-meta.css
@@ -1,0 +1,7 @@
+.sptp-meta .sptp-images,
+.sptp-meta .sptp-program,
+.sptp-meta .sptp-dates,
+.sptp-meta .sptp-gallery { margin-bottom:1em; }
+.sptp-meta img{max-width:80px;height:auto;display:block;margin-bottom:4px;}
+.sptp-meta button{margin:4px 0;}
+.sptp-meta .sptp-img-item,.sptp-gallery-item{display:inline-block;margin-right:10px;text-align:center;}

--- a/sp-tour-pages/assets/css/form.css
+++ b/sp-tour-pages/assets/css/form.css
@@ -1,0 +1,2 @@
+.sptp-form input[type="text"],.sptp-form input[type="tel"]{width:100%;padding:8px;margin-bottom:8px;border:1px solid #ccc;border-radius:4px;}
+.sptp-form button{background:#2196f3;color:#fff;border:none;padding:10px 20px;border-radius:4px;cursor:pointer;}

--- a/sp-tour-pages/assets/css/layout.css
+++ b/sp-tour-pages/assets/css/layout.css
@@ -1,0 +1,7 @@
+.sptp-page{padding:1rem;font-family:sans-serif;}
+.sptp-top-images{display:grid;grid-template-columns:repeat(3,1fr);grid-gap:4px;}
+.sptp-top-images img{width:100%;height:auto;border-radius:8px;}
+.sptp-gallery-scroll{display:flex;overflow-x:auto;gap:4px;margin:1em 0;}
+.sptp-gallery-scroll img{width:120px;height:auto;border-radius:6px;flex-shrink:0;}
+.sptp-action-bar{position:fixed;bottom:0;left:0;right:0;padding:10px;background:#fff;border-top:1px solid #ccc;text-align:center;}
+.sptp-book-btn{background:#ff6600;color:#fff;padding:10px 20px;border-radius:4px;text-decoration:none;}

--- a/sp-tour-pages/assets/css/tour-card.css
+++ b/sp-tour-pages/assets/css/tour-card.css
@@ -1,0 +1,9 @@
+.sptp-card{box-shadow:0 2px 6px rgba(0,0,0,.1);border-radius:8px;overflow:hidden;margin:1em 0;display:flex;flex-direction:column;background:#fff;}
+.sptp-card-img img{width:100%;height:auto;display:block;}
+.sptp-card-body{padding:1em;}
+.sptp-card-date{color:#555;margin-bottom:0.5em;}
+.sptp-card-price{font-weight:bold;color:#e91e63;}
+.sptp-card-badges .badge{display:inline-block;margin-right:4px;padding:2px 6px;border-radius:4px;font-size:0.8em;}
+.badge.hot{background:#ff5722;color:#fff;}
+.badge.new{background:#4caf50;color:#fff;}
+.sptp-card-link{display:inline-block;margin-top:0.5em;color:#2196f3;text-decoration:none;}

--- a/sp-tour-pages/assets/css/tour-page.css
+++ b/sp-tour-pages/assets/css/tour-page.css
@@ -1,0 +1,6 @@
+.sptp-acc-item{margin-bottom:5px;}
+.sptp-acc-btn{width:100%;text-align:left;padding:10px;background:#f5f5f5;border:none;border-radius:4px;}
+.sptp-acc-panel{display:none;padding:10px;border:1px solid #eee;border-top:none;}
+.sptp-acc-panel.open{display:block;}
+.sptp-price-item{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px dashed #ddd;}
+.sptp-price-item .hot{color:#ff5722;}

--- a/sp-tour-pages/assets/css/typography.css
+++ b/sp-tour-pages/assets/css/typography.css
@@ -1,0 +1,3 @@
+body{font-family:sans-serif;line-height:1.4;color:#333;}
+h1,h2,h3{font-weight:bold;margin:0.5em 0;}
+.sptp-card-title{font-size:1.2em;margin:0.5em 0;}

--- a/sp-tour-pages/assets/js/admin.js
+++ b/sp-tour-pages/assets/js/admin.js
@@ -1,0 +1,48 @@
+(function(){
+    document.addEventListener('click', function(e){
+        if(e.target.classList.contains('sptp-upload')){
+            e.preventDefault();
+            var btn = e.target;
+            var frame = wp.media({title:'Выбор изображения', multiple:false});
+            frame.on('select', function(){
+                var att = frame.state().get('selection').first().toJSON();
+                btn.previousElementSibling.value = att.id;
+                btn.previousElementSibling.previousElementSibling.src = att.sizes.thumbnail.url;
+            });
+            frame.open();
+        }
+        if(e.target.classList.contains('sptp-add-program')){
+            e.preventDefault();
+            var wrap = document.querySelector('.sptp-program');
+            var div = document.createElement('div');
+            div.className='sptp-program-item';
+            div.innerHTML='<textarea name="sp_program[]" rows="2" style="width:100%;"></textarea> <button class="sptp-remove">Удалить</button>';
+            wrap.appendChild(div);
+        }
+        if(e.target.classList.contains('sptp-add-date')){
+            e.preventDefault();
+            var wrap=document.querySelector('.sptp-dates');
+            var div=document.createElement('div');
+            div.className='sptp-date-item';
+            div.innerHTML='<input type="date" name="sp_dates[][date]" /> <input type="text" name="sp_dates[][price]" placeholder="Цена" /> <label><input type="checkbox" name="sp_dates[][hot]" />🔥</label> <button class="sptp-remove">Удалить</button>';
+            wrap.appendChild(div);
+        }
+        if(e.target.classList.contains('sptp-add-gallery')){
+            e.preventDefault();
+            var wrap=document.querySelector('.sptp-gallery');
+            var div=document.createElement('div');
+            div.className='sptp-gallery-item';
+            var frame=wp.media({title:'Галерея', multiple:false});
+            frame.on('select',function(){
+                var att=frame.state().get('selection').first().toJSON();
+                div.innerHTML='<input type="hidden" name="sp_gallery[]" value="'+att.id+'" /> <img src="'+att.sizes.thumbnail.url+'" /> <button class="sptp-remove">Удалить</button>';
+                wrap.appendChild(div);
+            });
+            frame.open();
+        }
+        if(e.target.classList.contains('sptp-remove')){
+            e.preventDefault();
+            e.target.parentNode.remove();
+        }
+    });
+})();

--- a/sp-tour-pages/assets/js/front.js
+++ b/sp-tour-pages/assets/js/front.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded',function(){
+    document.querySelectorAll('.sptp-acc-btn').forEach(function(btn){
+        btn.addEventListener('click',function(){
+            var panel=btn.nextElementSibling;
+            panel.classList.toggle('open');
+        });
+    });
+    var form=document.getElementById('sptp-form');
+    if(form){
+        form.addEventListener('submit',function(e){
+            e.preventDefault();
+            var fd=new FormData(form);
+            fd.append('action','sp_tour_send');
+            fd.append('nonce',sptpAjax.nonce);
+            fetch(sptpAjax.url,{method:'POST',body:fd}).then(r=>r.json()).then(function(){
+                alert('Заявка отправлена');
+                form.reset();
+            });
+        });
+    }
+});

--- a/sp-tour-pages/includes/class-sp-tour-cpt.php
+++ b/sp-tour-pages/includes/class-sp-tour-cpt.php
@@ -1,0 +1,33 @@
+<?php
+class SP_Tour_CPT {
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'register' ] );
+    }
+
+    public static function register() {
+        $labels = [
+            'name'               => 'Туры',
+            'singular_name'      => 'Тур',
+            'add_new'            => 'Добавить тур',
+            'add_new_item'       => 'Новый тур',
+            'edit_item'          => 'Редактировать тур',
+            'new_item'           => 'Новый тур',
+            'all_items'          => 'Все туры',
+            'view_item'          => 'Просмотр тура',
+            'search_items'       => 'Поиск туров',
+            'not_found'          => 'Туры не найдены',
+            'not_found_in_trash' => 'В корзине туры не найдены',
+            'menu_name'          => 'Туры'
+        ];
+
+        register_post_type( 'sp_tour', [
+            'labels'      => $labels,
+            'public'      => true,
+            'has_archive' => false,
+            'rewrite'     => [ 'slug' => 'tours' ],
+            'supports'    => [ 'title', 'thumbnail' ],
+            'menu_icon'   => 'dashicons-tickets-alt',
+            'show_in_rest' => true,
+        ] );
+    }
+}

--- a/sp-tour-pages/includes/class-sp-tour-hooks.php
+++ b/sp-tour-pages/includes/class-sp-tour-hooks.php
@@ -1,0 +1,56 @@
+<?php
+class SP_Tour_Hooks {
+    public static function init() {
+        add_filter( 'template_include', [ __CLASS__, 'template' ] );
+        add_filter( 'the_content', [ __CLASS__, 'add_cards' ] );
+        add_action( 'wp_enqueue_scripts', [ __CLASS__, 'assets' ] );
+    }
+
+    public static function template( $template ) {
+        if ( is_singular( 'sp_tour' ) ) {
+            return SPTP_PATH . 'templates/single-sp_tour.php';
+        }
+        return $template;
+    }
+
+    public static function assets() {
+        wp_enqueue_style( 'sptp-layout', SPTP_URL . 'assets/css/layout.css', [], '1.0' );
+        wp_enqueue_style( 'sptp-typography', SPTP_URL . 'assets/css/typography.css', [], '1.0' );
+        wp_enqueue_style( 'sptp-card', SPTP_URL . 'assets/css/tour-card.css', [], '1.0' );
+        wp_enqueue_style( 'sptp-page', SPTP_URL . 'assets/css/tour-page.css', [], '1.0' );
+        wp_enqueue_style( 'sptp-form', SPTP_URL . 'assets/css/form.css', [], '1.0' );
+        wp_enqueue_script( 'sptp-front', SPTP_URL . 'assets/js/front.js', [], '1.0', true );
+        wp_localize_script( 'sptp-front', 'sptpAjax', [
+            'url' => admin_url( 'admin-ajax.php' ),
+            'nonce' => wp_create_nonce( 'sptp_form' ),
+        ] );
+    }
+
+    public static function add_cards( $content ) {
+        if ( is_singular( 'page' ) && in_the_loop() && is_main_query() ) {
+            $page_id = get_the_ID();
+            $tours = get_posts( [
+                'post_type' => 'sp_tour',
+                'numberposts' => -1,
+                'meta_query' => [
+                    [
+                        'key' => SP_Tour_Meta::META_KEY,
+                        'value' => '"' . $page_id . '"',
+                        'compare' => 'LIKE'
+                    ]
+                ]
+            ] );
+            foreach ( $tours as $tour ) {
+                $content .= self::render_card( $tour->ID );
+            }
+        }
+        return $content;
+    }
+
+    public static function render_card( $post_id ) {
+        $data = get_post_meta( $post_id, SP_Tour_Meta::META_KEY, true );
+        ob_start();
+        include SPTP_PATH . 'templates/tour-card.php';
+        return ob_get_clean();
+    }
+}

--- a/sp-tour-pages/includes/class-sp-tour-meta.php
+++ b/sp-tour-pages/includes/class-sp-tour-meta.php
@@ -1,0 +1,76 @@
+<?php
+class SP_Tour_Meta {
+    const META_KEY = '_sp_tour_data';
+
+    public static function init() {
+        add_action( 'add_meta_boxes', [ __CLASS__, 'meta_box' ] );
+        add_action( 'save_post_sp_tour', [ __CLASS__, 'save' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_assets' ] );
+    }
+
+    public static function admin_assets( $hook ) {
+        if ( $hook === 'post.php' || $hook === 'post-new.php' ) {
+            wp_enqueue_media();
+            wp_enqueue_style( 'sptp-admin-meta', SPTP_URL . 'assets/css/admin-meta.css', [], '1.0' );
+            wp_enqueue_script( 'sptp-admin', SPTP_URL . 'assets/js/admin.js', [], '1.0', true );
+        }
+    }
+
+    public static function meta_box() {
+        add_meta_box( 'sp_tour_meta', 'Данные тура', [ __CLASS__, 'render' ], 'sp_tour', 'normal', 'high' );
+    }
+
+    public static function render( $post ) {
+        $data = get_post_meta( $post->ID, self::META_KEY, true );
+        $data = wp_parse_args( $data, [
+            'type' => '',
+            'short' => '',
+            'images' => [],
+            'program' => [],
+            'dates' => [],
+            'included' => '',
+            'extra' => '',
+            'depart' => '',
+            'return' => '',
+            'gallery' => [],
+            'badges' => [],
+            'pages' => []
+        ] );
+        wp_nonce_field( 'sp_tour_save', 'sp_tour_nonce' );
+        include SPTP_PATH . 'templates/admin-meta.php';
+    }
+
+    public static function save( $post_id ) {
+        if ( ! isset( $_POST['sp_tour_nonce'] ) || ! wp_verify_nonce( $_POST['sp_tour_nonce'], 'sp_tour_save' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        $fields = [
+            'type', 'short', 'included', 'extra', 'depart', 'return',
+        ];
+        $data = [];
+        foreach ( $fields as $field ) {
+            $data[ $field ] = sanitize_text_field( $_POST['sp_' . $field] ?? '' );
+        }
+        $data['images'] = array_map( 'absint', $_POST['sp_images'] ?? [] );
+        $data['program'] = array_map( 'sanitize_textarea_field', $_POST['sp_program'] ?? [] );
+        if ( isset( $_POST['sp_dates'] ) ) {
+            $dates = [];
+            foreach ( (array) $_POST['sp_dates'] as $d ) {
+                if ( empty( $d['date'] ) ) continue;
+                $dates[] = [
+                    'date' => sanitize_text_field( $d['date'] ),
+                    'price' => sanitize_text_field( $d['price'] ),
+                    'hot' => ! empty( $d['hot'] ) ? 1 : 0,
+                ];
+            }
+            $data['dates'] = $dates;
+        }
+        $data['gallery'] = array_map( 'absint', $_POST['sp_gallery'] ?? [] );
+        $data['badges'] = array_map( 'sanitize_text_field', $_POST['sp_badges'] ?? [] );
+        $data['pages'] = array_map( 'absint', $_POST['sp_pages'] ?? [] );
+        update_post_meta( $post_id, self::META_KEY, $data );
+    }
+}

--- a/sp-tour-pages/includes/class-sp-tour-telegram.php
+++ b/sp-tour-pages/includes/class-sp-tour-telegram.php
@@ -1,0 +1,28 @@
+<?php
+class SP_Tour_Telegram {
+    public static function init() {
+        add_action( 'wp_ajax_sp_tour_send', [ __CLASS__, 'send' ] );
+        add_action( 'wp_ajax_nopriv_sp_tour_send', [ __CLASS__, 'send' ] );
+    }
+
+    public static function send() {
+        check_ajax_referer( 'sptp_form', 'nonce' );
+        $name = sanitize_text_field( $_POST['name'] ?? '' );
+        $phone = sanitize_text_field( $_POST['phone'] ?? '' );
+        $tour = intval( $_POST['tour_id'] );
+        $message = "\xF0\x9F\x9A\xA9 Новая заявка\n";
+        $message .= "Тур: " . get_the_title( $tour ) . "\n";
+        $message .= "Имя: $name\nТелефон: $phone";
+        $token = defined('SP_TG_BOT_TOKEN') ? SP_TG_BOT_TOKEN : '';
+        $chat = defined('SP_TG_CHAT_ID') ? SP_TG_CHAT_ID : '';
+        if ( $token && $chat ) {
+            wp_remote_post( "https://api.telegram.org/bot{$token}/sendMessage", [
+                'body' => [
+                    'chat_id' => $chat,
+                    'text'    => $message
+                ]
+            ] );
+        }
+        wp_send_json_success();
+    }
+}

--- a/sp-tour-pages/sp-tour-pages.php
+++ b/sp-tour-pages/sp-tour-pages.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: SP Tour Pages
+ * Description: Create and display bus tour pages with modern design.
+ * Version: 1.0.0
+ * Author: Codex
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'SPTP_PATH', plugin_dir_path( __FILE__ ) );
+define( 'SPTP_URL', plugin_dir_url( __FILE__ ) );
+
+require_once SPTP_PATH . 'includes/class-sp-tour-cpt.php';
+require_once SPTP_PATH . 'includes/class-sp-tour-meta.php';
+require_once SPTP_PATH . 'includes/class-sp-tour-hooks.php';
+require_once SPTP_PATH . 'includes/class-sp-tour-telegram.php';
+
+SP_Tour_CPT::init();
+SP_Tour_Meta::init();
+SP_Tour_Hooks::init();
+SP_Tour_Telegram::init();

--- a/sp-tour-pages/templates/admin-meta.php
+++ b/sp-tour-pages/templates/admin-meta.php
@@ -1,0 +1,85 @@
+<div class="sptp-meta">
+    <p>
+        <label for="sp_type">Тип тура</label><br>
+        <select name="sp_type" id="sp_type">
+            <option value="one" <?php selected( $data['type'], 'one' ); ?>>Однодневный</option>
+            <option value="multi" <?php selected( $data['type'], 'multi' ); ?>>Многодневный</option>
+        </select>
+    </p>
+    <p>
+        <label for="sp_short">Краткое описание</label><br>
+        <textarea name="sp_short" id="sp_short" rows="3" style="width:100%;"><?php echo esc_textarea( $data['short'] ); ?></textarea>
+    </p>
+    <h4>Изображения (6)</h4>
+    <div class="sptp-images">
+        <?php for ( $i = 0; $i < 6; $i++ ) : $img = $data['images'][ $i ] ?? ''; ?>
+            <div class="sptp-img-item">
+                <input type="hidden" name="sp_images[]" value="<?php echo esc_attr( $img ); ?>" />
+                <img src="<?php echo $img ? wp_get_attachment_image_url( $img, 'thumbnail' ) : ''; ?>" />
+                <button class="sptp-upload">Выбрать</button>
+            </div>
+        <?php endfor; ?>
+    </div>
+    <h4>Программа тура</h4>
+    <div class="sptp-program" data-name="sp_program[]">
+        <?php foreach ( $data['program'] as $day ) : ?>
+            <div class="sptp-program-item">
+                <textarea name="sp_program[]" rows="2" style="width:100%;"><?php echo esc_textarea( $day ); ?></textarea>
+                <button class="sptp-remove">Удалить</button>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <button class="sptp-add-program">Добавить день</button>
+    <h4>Даты и цены</h4>
+    <div class="sptp-dates">
+        <?php foreach ( $data['dates'] as $d ) : ?>
+            <div class="sptp-date-item">
+                <input type="date" name="sp_dates[][date]" value="<?php echo esc_attr( $d['date'] ); ?>" />
+                <input type="text" name="sp_dates[][price]" placeholder="Цена" value="<?php echo esc_attr( $d['price'] ); ?>" />
+                <label><input type="checkbox" name="sp_dates[][hot]" <?php checked( $d['hot'], 1 ); ?> />🔥</label>
+                <button class="sptp-remove">Удалить</button>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <button class="sptp-add-date">Добавить дату</button>
+    <p>
+        <label for="sp_included">Что включено</label><br>
+        <textarea name="sp_included" id="sp_included" rows="2" style="width:100%;"><?php echo esc_textarea( $data['included'] ); ?></textarea>
+    </p>
+    <p>
+        <label for="sp_extra">Дополнительные расходы</label><br>
+        <textarea name="sp_extra" id="sp_extra" rows="2" style="width:100%;"><?php echo esc_textarea( $data['extra'] ); ?></textarea>
+    </p>
+    <p>
+        <label for="sp_depart">Отправление</label><br>
+        <input type="text" name="sp_depart" id="sp_depart" value="<?php echo esc_attr( $data['depart'] ); ?>" style="width:100%;" />
+    </p>
+    <p>
+        <label for="sp_return">Возвращение</label><br>
+        <input type="text" name="sp_return" id="sp_return" value="<?php echo esc_attr( $data['return'] ); ?>" style="width:100%;" />
+    </p>
+    <h4>Галерея</h4>
+    <div class="sptp-gallery" data-name="sp_gallery[]">
+        <?php foreach ( $data['gallery'] as $img ) : ?>
+            <div class="sptp-gallery-item">
+                <input type="hidden" name="sp_gallery[]" value="<?php echo esc_attr( $img ); ?>" />
+                <img src="<?php echo wp_get_attachment_image_url( $img, 'thumbnail' ); ?>" />
+                <button class="sptp-remove">Удалить</button>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <button class="sptp-add-gallery">Добавить изображение</button>
+    <p>
+        <label>Плашки</label><br>
+        <label><input type="checkbox" name="sp_badges[]" value="hot" <?php checked( in_array( 'hot', $data['badges'] ) ); ?> /> Горящая цена</label>
+        <label><input type="checkbox" name="sp_badges[]" value="new" <?php checked( in_array( 'new', $data['badges'] ) ); ?> /> Новый тур</label>
+    </p>
+    <p>
+        <label>Показывать на страницах</label><br>
+        <select name="sp_pages[]" multiple style="width:100%;max-height:150px;">
+            <?php foreach ( get_pages() as $page ) : ?>
+                <option value="<?php echo $page->ID; ?>" <?php selected( in_array( $page->ID, $data['pages'] ) ); ?>><?php echo esc_html( $page->post_title ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </p>
+</div>

--- a/sp-tour-pages/templates/single-sp_tour.php
+++ b/sp-tour-pages/templates/single-sp_tour.php
@@ -1,0 +1,52 @@
+<?php
+get_header();
+$data = get_post_meta( get_the_ID(), SP_Tour_Meta::META_KEY, true );
+?>
+<main class="sptp-page">
+    <div class="sptp-top-images">
+        <?php foreach ( $data['images'] as $img ) : ?>
+            <img src="<?php echo wp_get_attachment_image_url( $img, 'medium' ); ?>" />
+        <?php endforeach; ?>
+    </div>
+    <h1><?php the_title(); ?></h1>
+    <p class="sptp-short"><?php echo esc_html( $data['short'] ); ?></p>
+    <div class="sptp-program-list">
+        <?php foreach ( $data['program'] as $i => $day ) : ?>
+            <div class="sptp-acc-item">
+                <button class="sptp-acc-btn">День <?php echo $i+1; ?></button>
+                <div class="sptp-acc-panel"><p><?php echo nl2br( esc_html( $day ) ); ?></p></div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <div class="sptp-prices">
+        <?php foreach ( $data['dates'] as $d ) : ?>
+            <div class="sptp-price-item">
+                <span><?php echo date_i18n( 'd.m.Y', strtotime( $d['date'] ) ); ?></span>
+                <span><?php echo esc_html( $d['price'] ); ?></span>
+                <?php if ( ! empty( $d['hot'] ) ) : ?><span class="hot">🔥</span><?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <div class="sptp-info">
+        <p><strong>Что включено:</strong> <?php echo esc_html( $data['included'] ); ?></p>
+        <p><strong>Дополнительные расходы:</strong> <?php echo esc_html( $data['extra'] ); ?></p>
+        <p><strong>Отправление:</strong> <?php echo esc_html( $data['depart'] ); ?></p>
+        <p><strong>Возвращение:</strong> <?php echo esc_html( $data['return'] ); ?></p>
+    </div>
+    <div class="sptp-gallery-scroll">
+        <?php foreach ( $data['gallery'] as $img ) : ?>
+            <img src="<?php echo wp_get_attachment_image_url( $img, 'medium' ); ?>" />
+        <?php endforeach; ?>
+    </div>
+    <form class="sptp-form" id="sptp-form">
+        <input type="hidden" name="tour_id" value="<?php echo get_the_ID(); ?>" />
+        <p><input type="text" name="name" placeholder="Имя" required></p>
+        <p><input type="tel" name="phone" placeholder="Телефон" required></p>
+        <p><label><input type="checkbox" required> Согласен на обработку персональных данных</label></p>
+        <p><button type="submit">Отправить</button></p>
+    </form>
+    <p class="sptp-disclaimer">*Программа тура может отличаться...</p>
+    <div class="sptp-action-bar"><a href="#sptp-form" class="sptp-book-btn">Забронировать</a></div>
+</main>
+<?php
+get_footer();

--- a/sp-tour-pages/templates/tour-card.php
+++ b/sp-tour-pages/templates/tour-card.php
@@ -1,0 +1,32 @@
+<?php
+$nearest = '';
+$price = '';
+if ( ! empty( $data['dates'] ) ) {
+    usort( $data['dates'], function( $a, $b ){ return strcmp( $a['date'], $b['date'] ); } );
+    foreach ( $data['dates'] as $d ) {
+        if ( strtotime( $d['date'] ) >= strtotime( 'today' ) ) {
+            $nearest = date_i18n( 'd.m.Y', strtotime( $d['date'] ) );
+            $price = $d['price'];
+            $hot = $d['hot'];
+            break;
+        }
+    }
+}
+$badges = $data['badges'];
+?>
+<div class="sptp-card">
+    <?php if ( has_post_thumbnail( $post_id ) ) : ?>
+        <div class="sptp-card-img"><?php echo get_the_post_thumbnail( $post_id, 'medium' ); ?></div>
+    <?php endif; ?>
+    <div class="sptp-card-body">
+        <h3 class="sptp-card-title"><?php echo get_the_title( $post_id ); ?></h3>
+        <?php if ( $nearest ) : ?>
+            <div class="sptp-card-date"><?php echo esc_html( $nearest ); ?> — <span class="sptp-card-price"><?php echo esc_html( $price ); ?></span></div>
+        <?php endif; ?>
+        <div class="sptp-card-badges">
+            <?php if ( in_array( 'hot', $badges ) || ! empty( $hot ) ) : ?><span class="badge hot">🔥 Горящая цена</span><?php endif; ?>
+            <?php if ( in_array( 'new', $badges ) ) : ?><span class="badge new">Новый тур</span><?php endif; ?>
+        </div>
+        <a href="<?php echo get_permalink( $post_id ); ?>" class="sptp-card-link">Подробнее</a>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add `SP Tour Pages` WordPress plugin for managing bus tour pages
- include custom post type, meta fields, admin UI, Telegram form submission, and front-end templates
- provide CSS/JS assets for both admin and front-end

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcbdf7e90832c86e2848bf084901e